### PR TITLE
Add "blankOptionLabel" if includeBlankOption is active

### DIFF
--- a/src/FilterSetting/Checkbox.php
+++ b/src/FilterSetting/Checkbox.php
@@ -156,6 +156,10 @@ class Checkbox extends SimpleLookup
             );
         }
 
+        if ($arrWidget['eval']['includeBlankOption']) {
+            $arrWidget['eval']['blankOptionLabel'] = $GLOBALS['TL_LANG']['metamodels_frontendfilter']['do_not_filter'];
+        }
+
         $this->addFilterParam();
 
         return array


### PR DESCRIPTION
This adds the blankOptionLabel with translation key `$GLOBALS['TL_LANG']['metamodels_frontendfilter']['do_not_filter']`